### PR TITLE
Capture stdout/stderr from OS fd instead of Python's `sys.stdout` / `sys.stderr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ def distributed_training(model: nn.Module, num_steps: int = 10) -> nn.Module | N
 We can distribute and run this function (e.g. on 2 machines x 2 GPUs) using **`torchrunx`**!
 
 ```python
+import logging
+logging.basicConfig(level=logging.INFO)
+
 import torchrunx
 
 launcher = torchrunx.Launcher(

--- a/docs/source/usage/logging.md
+++ b/docs/source/usage/logging.md
@@ -1,6 +1,6 @@
 # Custom Logging
 
-We forward all agent and worker logs (i.e. from {mod}`logging`, {obj}`sys.stdout`, and {obj}`sys.stderr`) to the launcher process.
+We forward all agent and worker logs (i.e. from {mod}`logging`, `stdout`, and `stderr`) to the launcher process.
 
 ## Defaults
 


### PR DESCRIPTION
This approach will fix #85, and allows us to capture outputs to stdout/stderr from subprocesses. Still figuring out the details.